### PR TITLE
Added provisions to composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 *.swp
+nbproject

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,15 @@
 	"suggest": {
 		"ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker.",
 		"ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available.",
-        "ext-pcntl": "Good to have it on *nix systems (forking)"
-
-    },
+		"ext-pcntl": "Good to have it on *nix systems (forking)"
+	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*"
+	},
+	"provide": {
+		"chrisboulton/php-resque": "*",
+		"tozwierz/php-resque": "*",
+		"catch-of-the-day/php-resque": "*"
 	},
 	"bin": [
 		"bin/resque"


### PR DESCRIPTION
Composer's "provide" setting allows this fork to replace original library where other libs depend on it.
If another lib requires "chrisboulton/php-resque" and you list it under provide in your lib, composer will not look for original if this fork is loaded in project.
